### PR TITLE
[BE] fix: docker mysql error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ out/
 ### Properties ###
 application-*.yml
 
-/db_data/
+**/db_data/

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -2,6 +2,8 @@ version: '3.8'
 services:
   db:
     image: mysql:8.0.12
+    cap_add:
+      - SYS_NICE
     volumes:
       - ./db_data:/var/lib/mysql
     restart: always


### PR DESCRIPTION
## 작업 내용
- mysql  volume data를 gitignore 처리
- mbind: Operation not permitted 에러 해결
## 핵심 로직
- gitignore에 wildcard 패턴 추가
- MYSQL에 CAP_SYS_NICE 권한을 줘서 에러를 스스로 해결하게 함
## 관련 이슈
- close #16 