### PR TITLE
[BE] Mockito.when()을 BDDMockito.given()으로 변경

### DIFF
--- a/backend/src/test/java/com/bluepa/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/bluepa/backend/post/service/PostServiceTest.java
@@ -2,6 +2,7 @@ package com.bluepa.backend.post.service;
 
 import static org.mockito.ArgumentMatchers.any;
 
+import com.bluepa.backend.post.config.PostIndexNameConfig;
 import com.bluepa.backend.post.domain.Post;
 import com.bluepa.backend.post.repository.PostRepository;
 import java.util.Optional;
@@ -14,8 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.elasticsearch.core.geo.GeoJsonPoint;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -25,6 +26,9 @@ class PostServiceTest {
 
     @Mock
     PostRepository postRepository;
+
+    @Mock
+    PostIndexNameConfig postIndexNameConfig;
 
     Post post;
 
@@ -41,8 +45,8 @@ class PostServiceTest {
 
     @Test
     void 글쓰기() {
-        when(postRepository.save(any())).thenReturn(post);
-        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+        given(postRepository.save(any())).willReturn(post);
+        given(postRepository.findById(post.getId())).willReturn(Optional.of(post));
 
         String saveId = postService.write(post, "iksan");
         Post findPost = postService.findOne(saveId).get();

--- a/backend/src/test/java/com/bluepa/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/bluepa/backend/post/service/PostServiceTest.java
@@ -16,7 +16,7 @@ import org.springframework.data.elasticsearch.core.geo.GeoJsonPoint;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -51,9 +51,8 @@ class PostServiceTest {
         String saveId = postService.write(post, "iksan");
         Post findPost = postService.findOne(saveId).get();
 
-        verify(postRepository).save(any());
-        verify(postRepository).findById(post.getId());
-
+        then(postRepository).should().save(any());
+        then(postRepository).should().findById(post.getId());
         assertThat(post).isEqualTo(findPost);
     }
 }

--- a/backend/src/test/java/com/bluepa/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/bluepa/backend/user/service/UserServiceTest.java
@@ -2,8 +2,8 @@ package com.bluepa.backend.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.bluepa.backend.global.security.JwtProvider;
 import com.bluepa.backend.user.domain.EmailAuth;
@@ -61,9 +61,9 @@ public class UserServiceTest {
             .password(password)
             .build();
         EmailAuth emailAuth = new EmailAuth("aaa@gmail.com,123456,true");
-        when(passwordEncoder.encode(any())).thenReturn(password);
-        when(userRepository.save(any())).thenReturn(user);
-        when(emailAuthRepository.findByEmail(email)).thenReturn(Optional.of(emailAuth));
+        given(passwordEncoder.encode(any())).willReturn(password);
+        given(userRepository.save(any())).willReturn(user);
+        given(emailAuthRepository.findByEmail(email)).willReturn(Optional.of(emailAuth));
 
         Long userId = userService.signUp(signUpRequest);
 
@@ -78,9 +78,9 @@ public class UserServiceTest {
             .email(email)
             .password(password)
             .build();
-        when(passwordEncoder.matches(any(), any())).thenReturn(true);
-        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
-        when(provider.createToken(user)).thenReturn("token");
+        given(passwordEncoder.matches(any(), any())).willReturn(true);
+        given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
+        given(provider.createToken(user)).willReturn("token");
 
         String token = userService.signIn(signInRequest);
 
@@ -89,7 +89,7 @@ public class UserServiceTest {
 
     @Test
     void 이메일_전송() {
-        when(userRepository.existsByEmail(email)).thenReturn(false);
+        given(userRepository.existsByEmail(email)).willReturn(false);
 
         userService.sendEmail(email);
 
@@ -100,7 +100,7 @@ public class UserServiceTest {
     @Test
     void 이메일_인증() {
         EmailAuth emailAuth = new EmailAuth(email, 123456);
-        when(emailAuthRepository.findByEmail(email)).thenReturn(Optional.of(emailAuth));
+        given(emailAuthRepository.findByEmail(email)).willReturn(Optional.of(emailAuth));
 
         userService.authenticateEmail(email, 123456);
 

--- a/backend/src/test/java/com/bluepa/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/bluepa/backend/user/service/UserServiceTest.java
@@ -3,7 +3,7 @@ package com.bluepa.backend.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.then;
 
 import com.bluepa.backend.global.security.JwtProvider;
 import com.bluepa.backend.user.domain.EmailAuth;
@@ -67,8 +67,8 @@ public class UserServiceTest {
 
         Long userId = userService.signUp(signUpRequest);
 
-        verify(userRepository).save(any());
-        verify(emailAuthRepository).deleteByEmail(email);
+        then(userRepository).should().save(any());
+        then(emailAuthRepository).should().deleteByEmail(email);
         assertThat(userId).isEqualTo(user.getId());
     }
 
@@ -93,8 +93,8 @@ public class UserServiceTest {
 
         userService.sendEmail(email);
 
-        verify(emailAuthRepository).save(any());
-        verify(javaMailSender).send((SimpleMailMessage) any());
+        then(emailAuthRepository).should().save(any());
+        then(javaMailSender).should().send((SimpleMailMessage) any());
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- Mockito.when()을 BDDMockito.given()으로 변경
## 핵심 로직
**PostServiceTest**
```java
void 글쓰기() {
    given(postRepository.save(any())).willReturn(post);
    given(postRepository.findById(post.getId())).willReturn(Optional.of(post));

    String saveId = postService.write(post, "iksan");
    Post findPost = postService.findOne(saveId).get();

    verify(postRepository).save(any());
    verify(postRepository).findById(post.getId());

    assertThat(post).isEqualTo(findPost);
}
```
## 관련 이슈
- close #40 