### PR TITLE
[BE] Mockito를 BDDMockito로 변경

### DIFF
--- a/backend/src/test/java/com/bluepa/backend/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/bluepa/backend/post/service/PostServiceTest.java
@@ -1,11 +1,13 @@
 package com.bluepa.backend.post.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.bluepa.backend.post.config.PostIndexNameConfig;
 import com.bluepa.backend.post.domain.Post;
 import com.bluepa.backend.post.repository.JpaPostRepository;
-
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,10 +17,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.elasticsearch.core.geo.GeoJsonPoint;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -47,27 +45,26 @@ class PostServiceTest {
 
     @Test
     void 글쓰기() {
-        when(postRepository.save(any())).thenReturn(post);
-        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+        given(postRepository.save(any())).willReturn(post);
+        given(postRepository.findById(post.getId())).willReturn(Optional.of(post));
 
         String saveId = postService.write(post, "iksan");
         Post findPost = postService.findOne(saveId).get();
 
-        verify(postRepository).save(any());
-        verify(postRepository).findById(post.getId());
-        verify(postIndexNameConfig).setCityName("iksan");
-
+        then(postRepository).should().save(any());
+        then(postRepository).should().findById(post.getId());
+        then(postIndexNameConfig).should().setCityName("iksan");
         assertThat(post).isEqualTo(findPost);
     }
 
     @Test
     void 검색() {
-        when(postRepository.searchPost("test Title", GeoJsonPoint.of(123, 123))).thenReturn(List.of(post));
+        given(postRepository.searchPost("test Title", GeoJsonPoint.of(123, 123)))
+            .willReturn(List.of(post));
 
         List<Post> posts = postService.search("test Title", GeoJsonPoint.of(123, 123));
 
-        verify(postRepository).searchPost("test Title", GeoJsonPoint.of(123, 123));
-
+        then(postRepository).should().searchPost("test Title", GeoJsonPoint.of(123, 123));
         assertThat(post).isEqualTo(posts.get(0));
     }
 }

--- a/backend/src/test/java/com/bluepa/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/bluepa/backend/user/service/UserServiceTest.java
@@ -3,8 +3,7 @@ package com.bluepa.backend.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.then;
 
 import com.bluepa.backend.global.security.JwtProvider;
 import com.bluepa.backend.user.domain.EmailAuth;
@@ -65,14 +64,14 @@ public class UserServiceTest {
             .password(password)
             .build();
         EmailAuth emailAuth = new EmailAuth("aaa@gmail.com,123456,true");
-        when(passwordEncoder.encode(any())).thenReturn(password);
-        when(userRepository.save(any())).thenReturn(user);
-        when(emailAuthRepository.findByEmail(email)).thenReturn(Optional.of(emailAuth));
+        given(passwordEncoder.encode(any())).willReturn(password);
+        given(userRepository.save(any())).willReturn(user);
+        given(emailAuthRepository.findByEmail(email)).willReturn(Optional.of(emailAuth));
 
         Long userId = userService.signUp(signUpRequest);
 
-        verify(userRepository).save(any());
-        verify(emailAuthRepository).deleteByEmail(email);
+        then(userRepository).should().save(any());
+        then(emailAuthRepository).should().deleteByEmail(email);
         assertThat(userId).isEqualTo(user.getId());
     }
 
@@ -82,9 +81,9 @@ public class UserServiceTest {
             .email(email)
             .password(password)
             .build();
-        when(passwordEncoder.matches(any(), any())).thenReturn(true);
-        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
-        when(provider.createToken(user)).thenReturn("token");
+        given(passwordEncoder.matches(any(), any())).willReturn(true);
+        given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
+        given(provider.createToken(user)).willReturn("token");
 
         String token = userService.signIn(signInRequest);
 
@@ -104,18 +103,18 @@ public class UserServiceTest {
 
     @Test
     void 이메일_전송() {
-        when(userRepository.existsByEmail(email)).thenReturn(false);
+        given(userRepository.existsByEmail(email)).willReturn(false);
 
         userService.sendEmail(email);
 
-        verify(emailAuthRepository).save(any());
-        verify(javaMailSender).send((SimpleMailMessage) any());
+        then(emailAuthRepository).should().save(any());
+        then(javaMailSender).should().send((SimpleMailMessage) any());
     }
 
     @Test
     void 이메일_인증() {
         EmailAuth emailAuth = new EmailAuth(email, 123456);
-        when(emailAuthRepository.findByEmail(email)).thenReturn(Optional.of(emailAuth));
+        given(emailAuthRepository.findByEmail(email)).willReturn(Optional.of(emailAuth));
 
         userService.authenticateEmail(email, 123456);
 


### PR DESCRIPTION
## 작업 내용
- Mockito의 when()을 BDDMockito의 given() 으로 변경
- Mockito의 verify()를 BDDMockito의 then().should() 로 변경
## 핵심 로직
```java
@Test
void 이메일_전송() {
    given(userRepository.existsByEmail(email)).willReturn(false);

    userService.sendEmail(email);

    then(emailAuthRepository).should().save(any());
    then(javaMailSender).should().send((SimpleMailMessage) any());
}
```
## 관련 이슈
- close #40