### PR TITLE
[BE] docker compose start order

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,14 @@
+FROM gradle:jdk11 AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon
+
 FROM openjdk:11-jdk-slim
-VOLUME /tmp
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+
+EXPOSE 8080
+
+RUN mkdir /app
+
+COPY --from=build /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar
+
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app/spring-boot-application.jar"]

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -34,22 +34,25 @@ services:
       - elastic
 
   app:
-    depends_on:
-      - db
-      - elasticsearch
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        - JAR_FILE=build/libs/*.jar
     ports:
       - 3000:3000
+    command:
+      - sh
+      - -c
+      - "bin/wait-for db:3306 -- bundle exec rails s;
+        bin/wait-for elasticsearch:9200 -- bundle exec rails s"
     environment:
       MYSQL_DB_HOST: db:3306
       MYSQL_DB_USER: test
       MYSQL_DB_PASSWORD: test
       MYSQL_DB_NAME: bluepa
       ELASTICSEARCH_HOST: elasticsearch:9200
+    depends_on:
+      - db
+      - elasticsearch
 
 networks:
   elastic:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
     generate-ddl: true
     show-sql: true
   datasource:
+    url: jdbc:mysql://${MYSQL_DB_HOST}/${MYSQL_DB_NAME}?autoReconnect=true
+    username: ${MYSQL_DB_USER}
+    password: ${MYSQL_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   mail:
     host: smtp.gmail.com

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -52,8 +52,8 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-  elasticsearch:
-    host: ${ELASTICSEARCH_HOST}
+elasticsearch:
+  host: ${ELASTICSEARCH_HOST}
 server:
   error:
     include-message: always


### PR DESCRIPTION
## 작업 내용
- Container start order 
- Dockerfile에 gradle build 추가
- application.yml에 db configuration 추가
## 핵심 로직
- ### at Docker-compose.yaml
```yaml
app:
    build:
      context: .
      dockerfile: Dockerfile
    ports:
      - 3000:3000
    command:
      - sh
      - -c
      - "bin/wait-for db:3306 -- bundle exec rails s;
        bin/wait-for elasticsearch:9200 -- bundle exec rails s"
```
- ### at Dockerfile
```Dockerfile
FROM gradle:jdk11 AS build
COPY --chown=gradle:gradle . /home/gradle/src
WORKDIR /home/gradle/src
RUN gradle build --no-daemon

FROM openjdk:11-jdk-slim

EXPOSE 8080

RUN mkdir /app

COPY --from=build /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar

ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app/spring-boot-application.jar"]
```
- ### at application.yml
```yml
datasource:
    url: jdbc:mysql://${MYSQL_DB_HOST}/${MYSQL_DB_NAME}?autoReconnect=true
    username: ${MYSQL_DB_USER}
    password: ${MYSQL_DB_PASSWORD}
    driver-class-name: com.mysql.cj.jdbc.Driver
```
## 관련 이슈
- close #24
- close #38